### PR TITLE
feat(tooling): implementa Turborepo para orquestração de tarefas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@ package-lock.json
 .yarn/unplugged
 .yarn/build-state
 .yarn/install-state.gz 
+
+.turbo

--- a/client/eslint.config.js
+++ b/client/eslint.config.js
@@ -1,4 +1,4 @@
-import rootConfig from '../../eslint.config.mjs';
+import rootConfig from '../eslint.config.mjs';
 
 import globals from 'globals';
 import eslintPluginReact from 'eslint-plugin-react';

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -9,10 +9,10 @@ function App() {
   return (
     <>
       <div>
-        <a href="https://vite.dev" target="_blank">
+        <a href="https://vite.dev" target="_blank" rel="noreferrer">
           <img src={viteLogo} className="logo" alt="Vite logo" />
         </a>
-        <a href="https://react.dev" target="_blank">
+        <a href="https://react.dev" target="_blank" rel="noreferrer">
           <img src={reactLogo} className="logo react" alt="React logo" />
         </a>
       </div>

--- a/package.json
+++ b/package.json
@@ -7,10 +7,12 @@
     "server"
   ],
   "scripts": {
+    "dev": "turbo run dev",
+    "build": "turbo run build",
+    "lint": "turbo run lint",
+    "start": "turbo run start",
     "format": "prettier --write \"**/*.{ts,tsx,js,jsx,json,md,prisma}\"",
     "format:check": "prettier --check \"**/*.{ts,tsx,js,jsx,json,md,prisma}\"",
-    "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-    "lint:fix": "eslint . --ext .js,.jsx,.ts,.tsx --fix",
     "prepare": "husky"
   },
   "devDependencies": {
@@ -25,6 +27,7 @@
     "lint-staged": "^16.1.0",
     "prettier": "^3.5.3",
     "prettier-plugin-prisma": "^5.0.0",
+    "turbo": "^2.5.4",
     "typescript": "^5.8.3",
     "typescript-eslint": "^8.33.0"
   },

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,9 @@
     "start": "node ./dist/server.js",
     "build": "tsc",
     "dev": "nodemon --watch 'src/**/*.ts' --exec 'node -r dotenv/config --loader ts-node/esm src/server.ts'",
-    "prisma:seed": "node -r dotenv/config --loader ts-node/esm prisma/seed.ts"
+    "prisma:seed": "node -r dotenv/config --loader ts-node/esm prisma/seed.ts",
+    "lint": "eslint src/ --ext .ts",
+    "postinstall": "prisma generate"
   },
   "dependencies": {
     "@libsql/client": "^0.15.8",

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["**/.env.*", "tsconfig.json"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
+    },
+    "lint": {},
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "start": {
+      "dependsOn": ["build"]
+    },
+    "clean": {
+      "cache": false
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2434,6 +2434,7 @@ __metadata:
     lint-staged: "npm:^16.1.0"
     prettier: "npm:^3.5.3"
     prettier-plugin-prisma: "npm:^5.0.0"
+    turbo: "npm:^2.5.4"
     typescript: "npm:^5.8.3"
     typescript-eslint: "npm:^8.33.0"
   languageName: unknown
@@ -6067,6 +6068,77 @@ __metadata:
   version: 2.8.1
   resolution: "tslib@npm:2.8.1"
   checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
+  languageName: node
+  linkType: hard
+
+"turbo-darwin-64@npm:2.5.4":
+  version: 2.5.4
+  resolution: "turbo-darwin-64@npm:2.5.4"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"turbo-darwin-arm64@npm:2.5.4":
+  version: 2.5.4
+  resolution: "turbo-darwin-arm64@npm:2.5.4"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"turbo-linux-64@npm:2.5.4":
+  version: 2.5.4
+  resolution: "turbo-linux-64@npm:2.5.4"
+  conditions: os=linux & cpu=x64
+  languageName: node
+  linkType: hard
+
+"turbo-linux-arm64@npm:2.5.4":
+  version: 2.5.4
+  resolution: "turbo-linux-arm64@npm:2.5.4"
+  conditions: os=linux & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"turbo-windows-64@npm:2.5.4":
+  version: 2.5.4
+  resolution: "turbo-windows-64@npm:2.5.4"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"turbo-windows-arm64@npm:2.5.4":
+  version: 2.5.4
+  resolution: "turbo-windows-arm64@npm:2.5.4"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"turbo@npm:^2.5.4":
+  version: 2.5.4
+  resolution: "turbo@npm:2.5.4"
+  dependencies:
+    turbo-darwin-64: "npm:2.5.4"
+    turbo-darwin-arm64: "npm:2.5.4"
+    turbo-linux-64: "npm:2.5.4"
+    turbo-linux-arm64: "npm:2.5.4"
+    turbo-windows-64: "npm:2.5.4"
+    turbo-windows-arm64: "npm:2.5.4"
+  dependenciesMeta:
+    turbo-darwin-64:
+      optional: true
+    turbo-darwin-arm64:
+      optional: true
+    turbo-linux-64:
+      optional: true
+    turbo-linux-arm64:
+      optional: true
+    turbo-windows-64:
+      optional: true
+    turbo-windows-arm64:
+      optional: true
+  bin:
+    turbo: bin/turbo
+  checksum: 10c0/81af22a24ca643d25f344184e4f37b8b70f118c9a3af13e6b6604b652eb0a7d98fdb03c195457ed1831ecf246ef06cb9566ae3e361d105fe89fbcdbb3f135c38
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Adiciona Turborepo como dependência de desenvolvimento na raiz.
- Cria e configura o arquivo `turbo.json` com o pipeline de tarefas (dev, build, lint, start).
- Atualiza os scripts no `package.json` da raiz para utilizar `turbo run`.
- Adiciona script de 'lint' ao `package.json` do servidor e `postinstall` para rodar `prisma generate` automaticamente, garantindo a compatibilidade com o Turborepo.